### PR TITLE
Adds existing test for ft_striteri

### DIFF
--- a/srcs/variables.sh
+++ b/srcs/variables.sh
@@ -46,15 +46,15 @@ Part1_func=('ft_memset.c' 'ft_bzero.c' 'ft_calloc.c' 'ft_memcpy.c' 'ft_memccpy.c
 #                 Part2 functions                 #
 ###################################################
 
-Part2_func_authorized=('1' '1' '1' '1' '3' \
+Part2_func_authorized=('1' '1' '1' '1' '1' '3' \
 '1' \
 '4' '4' '4' '4')
 
-Part2_func_activation=('0' '0' \
+Part2_func_activation=('0' '0' '0' \
 '0' '0' '0' '0' '0' \
 '0' '0' '0')
 
-Part2_func=('ft_strmapi.c' 'ft_substr.c' 'ft_strjoin.c' 'ft_strtrim.c' 'ft_split.c' \
+Part2_func=('ft_strmapi.c' 'ft_striteri.c' 'ft_substr.c' 'ft_strjoin.c' 'ft_strtrim.c' 'ft_split.c' \
 'ft_itoa.c' \
 'ft_putchar_fd.c' 'ft_putstr_fd.c' 'ft_putendl_fd.c' 'ft_putnbr_fd.c')
 


### PR DESCRIPTION
There is already a working test for **ft_striteri**, but it is not being called by the grademe script.

This adds the missing function to the variables list, just like the other functions:
![image](https://user-images.githubusercontent.com/26127185/128651730-fc1e95ab-53c6-435a-ac62-dd1fc0df8aba.png)
