### PR TITLE
Fix unused variable warning for char *bullshit

### DIFF
--- a/tests/Part2_functions/ft_substr/main.c
+++ b/tests/Part2_functions/ft_substr/main.c
@@ -6,7 +6,7 @@
 /*   By: jtoty <jtoty@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2017/02/28 12:35:18 by jtoty             #+#    #+#             */
-/*   Updated: 2019/12/04 21:51:40 by lmartin          ###   ########.fr       */
+/*   Updated: 2021/11/10 14:58:30 by ocartier         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,6 +85,7 @@ int		main(int argc, const char *argv[])
 		}
 		if (str == strsub)
 			ft_print_result("\nA new string was not returned");
+		(void)bullshit;
 	}
 	return (0);
 }


### PR DESCRIPTION
Problem found under Fedora Linux with gcc : the `bullshit` variable of **main.c** of **ft_substr** is not used and generates a warning :
```
/xxx/libft-war-machine/tests/Part2_fun
ctions/ft_substr/main.c:74:9: error: variable 'bullshit' set but not used [-Werror,-Wunused-bu
t-set-variable]                                                                               
                char *bullshit;
```

Fix simple : `(void)bullshit` at the end.